### PR TITLE
Update Excel.Range.Range.md

### DIFF
--- a/api/Excel.Range.Range.md
+++ b/api/Excel.Range.Range.md
@@ -68,7 +68,7 @@ This example sets the font style in cells B2:D6 on Sheet1 of the active workbook
 
 ```vb
 With Worksheets("Sheet1").Range("B2:Z22")
-   .Range(.Cells(1, 1), .Cells(5, 3)).Font.Italic = True 
+   .Range(Cells(1, 1), Cells(5, 3)).Font.Italic = True 
 End With
 ```
 


### PR DESCRIPTION
Removed extra dots/periods before Cells property.  The unfixed code actually changes "C3:E7" (not "B2:D6")